### PR TITLE
Add an option to shrink the borders of all affordance of a given size

### DIFF
--- a/idl/hpp/corbaserver/affordance/affordance.idl
+++ b/idl/hpp/corbaserver/affordance/affordance.idl
@@ -90,12 +90,12 @@ module hpp
 				/// given object. Affordances are added to a container in problemSolver
 				///
 				/// \param obstacleName Name of the collisionObstacle to be analysed
-        void analyseObject (in string obstacleName) raises (Error);
+        void analyseObject (in string obstacleName,in doubleSeq reduceSizes) raises (Error);
 				
 				/// creates collisionObjects for each affordance found in
 				/// the scene (goes through all obstacles). Affordances are added to 
 				/// a container in problemSolver.
-				void analyseAll () raises (Error);
+                                void analyseAll (in doubleSeq reduceSizes) raises (Error);
 
 				/// deletes all affordance objects of given obstacle.
 				///

--- a/src/affordance.impl.hh
+++ b/src/affordance.impl.hh
@@ -57,11 +57,11 @@ namespace hpp
         bool checkModel (const char* obstacleName) throw (hpp::Error);
 
 				void affordanceAnalysis (const char* obstacleName, 
-					const affordance::OperationBases_t & operations) throw (hpp::Error);
+                    const affordance::OperationBases_t & operations,std::vector<double> reduceSizes=std::vector<double>()) throw (hpp::Error);
 
-				void analyseObject (const char* obstacleName) throw (hpp::Error);
+                void analyseObject (const char* obstacleName, const hpp::doubleSeq& reduceSizesCorba) throw (hpp::Error);
 				
-				void analyseAll () throw (hpp::Error);
+                void analyseAll (const hpp::doubleSeq& reduceSizesCorba) throw (hpp::Error);
 
 				void deleteAffordancesByType (const char* affordance,
 					const char* obstacleName) throw (hpp::Error);

--- a/src/hpp/corbaserver/affordance/affordance.py
+++ b/src/hpp/corbaserver/affordance/affordance.py
@@ -105,16 +105,20 @@ class AffordanceTool (object):
     #		
     #		All found affordance objects are added to their corresponding
     # 	container in problem solver.
-    def analyseAll (self):
-        return self.client.affordance.affordance.analyseAll ()
+    #  \param reduceSizes : dimension of the reduction applied to the plan (to shrink the borders of each affordances plans)
+    #    The order of the value in the vector correspond to the order of the affordance type creation in affordance.impl.cc : Afford::createOperations ()
+    def analyseAll (self,reduceSizes=[]):
+        return self.client.affordance.affordance.analyseAll (reduceSizes)
 
     ## \biref Analyse one object by name
     #
     #		Found affordance objects are added to a container in problem solver.
     #
     #  \param objectName name of the object to analyse.
-    def analyseObject (self, objectName):
-        return self.client.affordance.affordance.analyseObject (objectName)
+    #  \param reduceSizes : dimension of the reduction applied to the plan (to shrink the borders of each affordances plans)
+    #    The order of the value in the vector correspond to the order of the affordance type creation in affordance.impl.cc : Afford::createOperations ()
+    def analyseObject (self, objectName,reduceSizes):
+        return self.client.affordance.affordance.analyseObject (objectName,reduceSizes)
 
     ## \brief Get vertex points of all triangles of an affordance type.
     #
@@ -171,7 +175,7 @@ class AffordanceTool (object):
     #         (collada, stl,...) if different from package
     #  \param guiOnly whether to control only gepetto-viewer-server
     def loadObstacleModel (self, package, filename, prefix, \
-		  Viewer, meshPackageName=None, guiOnly=False):
+                  Viewer, meshPackageName=None, guiOnly=False,reduceSizes=[]):
         Viewer.loadObstacleModel (package, filename, prefix, \
             meshPackageName, guiOnly)
         import re
@@ -179,7 +183,7 @@ class AffordanceTool (object):
         for name in objNames:
           splt = re.split ('/', name)
           if splt[0] == prefix :
-            self.analyseObject (name)
+            self.analyseObject (name,reduceSizes)
         return
 
     ## \brief Visualise all found affordance surfaces for an affordance type.


### PR DESCRIPTION
See https://github.com/humanoid-path-planner/hpp-affordance/pull/3
Add an optionnal argument in LoadObstacleModel : _reduceSizes_
This argument is a vector that define the desired size for the reduction of the Affordances plane. The first element is for the 'Support' affordance and the second for the 'Lean' affordance.

We should improve the API if we add more affordance types.